### PR TITLE
Changing origin to array in Flightcontrol Graphql

### DIFF
--- a/flightcontrol/api/src/functions/graphql.ts
+++ b/flightcontrol/api/src/functions/graphql.ts
@@ -19,7 +19,7 @@ export const handler = createGraphQLHandler({
   sdls,
   services,
   cors: {
-    origin: process.env.REDWOOD_WEB_URL,
+    origin: [process.env.REDWOOD_WEB_URL],
     credentials: true,
   },
   onException: () => {


### PR DESCRIPTION
This PR changes the CORS origin configuration to an array instead of single string value, to test whether that overcome the Yoga issue.
Related to issue #5344