### PR TITLE
chore: follow `@next` tag, not `@canary`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
     {
       "ignoreUnstable": false,
       "packageNames": ["@redwoodjs/core", "@redwoodjs/forms", "@redwoodjs/router", "@redwoodjs/web", "@redwoodjs/api", "@redwoodjs/graphql-server"],
-      "followTag": "canary",
+      "followTag": "next",
       "labels": ["automerge"]
     }    
   ],


### PR DESCRIPTION
We want to test deploy target ci using the next branch because it's where we'll be cutting releases from during the v4 release cycle