### PR TITLE
fix(flightcontrol): bump up health check timeouts

### DIFF
--- a/flightcontrol/flightcontrol.json
+++ b/flightcontrol/flightcontrol.json
@@ -21,6 +21,8 @@
           "startCommand": "cd flightcontrol && yarn rw deploy flightcontrol api --serve",
           "port": 8911,
           "healthCheckPath": "/graphql/health",
+          "healthCheckGracePeriodSecs": 10,
+          "healthCheckTimeoutSecs": 10,
           "envVariables": {
             "REDWOOD_WEB_URL": {
               "fromService": {


### PR DESCRIPTION
We're seeing failures which appear to be because the machine is under heavy load and the health checks are suffering false negatives as a result. We're bumping up the associated timeouts to try and fix this.