### PR TITLE
coherence: set log level to debug

### DIFF
--- a/coherence/api/src/lib/logger.ts
+++ b/coherence/api/src/lib/logger.ts
@@ -14,4 +14,8 @@ import { createLogger } from '@redwoodjs/api/logger'
  * @param {string | DestinationStream} destination - defines where to log, such as a transport stream or file
  * @param {boolean} showConfig - whether to display logger configuration on initialization
  */
-export const logger = createLogger({})
+export const logger = createLogger({
+  options: {
+    level: 'debug',
+  }
+})


### PR DESCRIPTION
We could do with some more verbose logging to try debug a 404 issue on the uptime checking.